### PR TITLE
feat/controller: add typethis controller for reset functionality

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,19 +10,27 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final typeThisWidget = TypeThis(
+      string: 'Hi there! How are you doing?',
+      speed: 100,
+      style: const TextStyle(fontSize: 20),
+    );
+
     return MaterialApp(
       title: 'Flutter TypeThis Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
+        primarySwatch: Colors.deepPurple,
       ),
-      home: const Scaffold(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('TypeThis Example'),
+        ),
         body: Center(
-          child: TypeThis(
-            string: 'Hello how are you doing?',
-            speed: 100,
-            style: TextStyle(fontSize: 20),
-          ),
+          child: typeThisWidget,
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => typeThisWidget.controller.reset(),
+          child: const Icon(Icons.refresh),
         ),
       ),
     );

--- a/lib/src/typethis.dart
+++ b/lib/src/typethis.dart
@@ -141,9 +141,9 @@ class TypeThis extends StatefulWidget {
   /// A [TypeThisController] that listens to steps attached
   /// with a timer. Listens to the [ChangeNotifier], and helps rebuild
   /// the widget after each `notifyListeners()`.
-  /// 
+  ///
   /// This variable is public for testing.
-  /// 
+  ///
   /// DO NOT use this variable. Instead, use the `controller` getter.
   @visibleForTesting
   final TypeThisController typeThisController;

--- a/lib/src/typethis_controller.dart
+++ b/lib/src/typethis_controller.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// {@template typethis_controller}
+/// A controller for the [TypeThis] widget.
+///
+/// It facilitates different operations on the typing animation.
+/// For example, the `reset()` method resets the typing animation,
+/// and restarts it from the beginning.
+///
+/// Remember to [dispose] of the [TypeThisController] when it is no longer
+/// needed. This will ensure we discard any resources used by the object.
+/// {@endtemplate}
+class TypeThisController with ChangeNotifier {
+  // Track the steps
+  int _steps = 0;
+
+  // Getter to track the step. Each step means adding a character
+  // to the typing animation.
+  int get steps => _steps;
+
+  // Duration on which [Timer.periodic] will run.
+  final Duration _periodicDuration;
+
+  // Length of the string
+  final int _maxBoundLength;
+
+  // Tracks the timer to reset and cancel when dispose.
+  @visibleForTesting
+  Timer? timer;
+
+  /// {@macro typethis_controller}
+  TypeThisController(Duration duration, int maxBoundLength)
+      : _periodicDuration = duration,
+        _maxBoundLength = maxBoundLength {
+    _startTimerAndNotify();
+  }
+
+  // Starts the timer and notifies the listener as a callback.
+  void _startTimerAndNotify() {
+    timer = Timer.periodic(_periodicDuration, (_) {
+      _steps++;
+      notifyListeners();
+
+      if (_steps == _maxBoundLength) {
+        timer?.cancel();
+      }
+    });
+  }
+
+  /// Resets the typing animation and restarts it from beginning.
+  ///
+  /// ```dart
+  /// // Extract the [TypeThis] widget into a separate variable.
+  /// final typeThisWidget = TypeThis(
+  ///   string: 'Hi there! How are you doing?',
+  ///   speed: 50,
+  ///   style: TextStyle(fontSize: 18, color: Colors.black),
+  /// );
+  ///
+  /// // Resets the animation
+  /// typeThisWidget.controller.reset();
+  /// ```
+  void reset() {
+    timer?.cancel();
+    _steps = 0;
+    _startTimerAndNotify();
+  }
+
+  @override
+  void dispose() {
+    timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/typethis.dart
+++ b/lib/typethis.dart
@@ -1,4 +1,5 @@
 library typethis;
 
-export 'src/typethis.dart';
 export 'src/blinking_cursor.dart';
+export 'src/typethis.dart';
+export 'src/typethis_controller.dart';

--- a/test/typethis_controller_test.dart
+++ b/test/typethis_controller_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:typethis/typethis.dart';
+
+void main() {
+  group('TypeThisController', () {
+    test('initial values are set correctly', () {
+      final controller = TypeThisController(const Duration(seconds: 1), 10);
+      expect(controller.steps, 0);
+    });
+
+    test('timer increments steps and notifies listeners', () async {
+      final controller = TypeThisController(const Duration(milliseconds: 100), 5);
+      expect(controller.steps, 0);
+
+      await Future.delayed(const Duration(milliseconds: 350));
+      expect(controller.steps, 3);
+    });
+
+    test('timer stops when steps reach maxBoundLength', () async {
+      final controller = TypeThisController(const Duration(milliseconds: 100), 3);
+
+      await Future.delayed(const Duration(milliseconds: 400));
+      expect(controller.steps, 3);
+
+      expect(controller.timer?.isActive, false);
+    });
+
+    test('reset method resets the controller', () async {
+      final controller = TypeThisController(const Duration(milliseconds: 100), 5);
+      final previousTimer = controller.timer;
+
+      await Future.delayed(const Duration(milliseconds: 300));
+      controller.reset();
+
+      expect(controller.steps, 0);
+      expect(previousTimer?.isActive, false);
+      expect(controller.timer?.isActive, true);
+    });
+
+    test('multiple resets work correctly', () async {
+      final controller = TypeThisController(const Duration(milliseconds: 100), 5);
+      final firstTimer = controller.timer;
+
+      await Future.delayed(const Duration(milliseconds: 300));
+      controller.reset();
+      final secondTimer = controller.timer;
+
+      await Future.delayed(const Duration(milliseconds: 200));
+      controller.reset();
+
+      expect(controller.steps, 0);
+
+      expect(firstTimer?.isActive, false);
+      expect(secondTimer?.isActive, false);
+      expect(controller.timer?.isActive, true);
+    });
+  });
+}

--- a/test/typethis_controller_test.dart
+++ b/test/typethis_controller_test.dart
@@ -9,7 +9,10 @@ void main() {
     });
 
     test('timer increments steps and notifies listeners', () async {
-      final controller = TypeThisController(const Duration(milliseconds: 100), 5);
+      final controller = TypeThisController(
+        const Duration(milliseconds: 100),
+        5,
+      );
       expect(controller.steps, 0);
 
       await Future.delayed(const Duration(milliseconds: 350));
@@ -17,7 +20,10 @@ void main() {
     });
 
     test('timer stops when steps reach maxBoundLength', () async {
-      final controller = TypeThisController(const Duration(milliseconds: 100), 3);
+      final controller = TypeThisController(
+        const Duration(milliseconds: 100),
+        3,
+      );
 
       await Future.delayed(const Duration(milliseconds: 400));
       expect(controller.steps, 3);
@@ -26,7 +32,10 @@ void main() {
     });
 
     test('reset method resets the controller', () async {
-      final controller = TypeThisController(const Duration(milliseconds: 100), 5);
+      final controller = TypeThisController(
+        const Duration(milliseconds: 100),
+        5,
+      );
       final previousTimer = controller.timer;
 
       await Future.delayed(const Duration(milliseconds: 300));
@@ -38,7 +47,10 @@ void main() {
     });
 
     test('multiple resets work correctly', () async {
-      final controller = TypeThisController(const Duration(milliseconds: 100), 5);
+      final controller = TypeThisController(
+        const Duration(milliseconds: 100),
+        5,
+      );
       final firstTimer = controller.timer;
 
       await Future.delayed(const Duration(milliseconds: 300));

--- a/test/typethis_test.dart
+++ b/test/typethis_test.dart
@@ -9,7 +9,7 @@ void main() {
     const testString = 'This is a test string';
     const testSpeed = 50;
 
-    Widget buildSubject({
+    TypeThis buildSubject({
       String string = testString,
       int speed = testSpeed,
       bool showBlinkingCursor = false,
@@ -28,7 +28,7 @@ void main() {
     group(': constructor', () {
       test('works perfectly', () {
         expect(
-          () => const TypeThis(string: testString),
+          () => TypeThis(string: testString),
           returnsNormally,
         );
       });
@@ -37,6 +37,16 @@ void main() {
         expect(
           () => buildSubject(speed: -10),
           throwsA(isA<AssertionError>()),
+        );
+      });
+    });
+
+    group(': controller', () {
+      test('works perfectly', () {
+        final typeThisWidget = buildSubject();
+        expect(
+          typeThisWidget.typeThisController,
+          equals(typeThisWidget.controller),
         );
       });
     });
@@ -76,7 +86,9 @@ void main() {
           'has finished rendereing and whole string is present',
           (widgetTester) async {
             await widgetTester.pumpApp(buildSubject());
-            await widgetTester.pumpAndSettle();
+            await widgetTester.pump(
+              const Duration(milliseconds: testSpeed * testString.length),
+            );
 
             final finder = find.byType(Text);
             expect(finder, findsOneWidget);


### PR DESCRIPTION
## Description

Add `TypeThisController` to introduce reset functionality for the typing animation. The `reset` function will reset and restart the typing animation from the beginning.

```dart
// Extract the [TypeThis] widget into a separate variable.
final typeThisWidget = TypeThis(
  string: 'Hi there! How are you doing?',
  speed: 50,
  style: TextStyle(fontSize: 18, color: Colors.black),
);
  
// Resets the animation
typeThisWidget.controller.reset();
```

## Type of Pull Request

- [ ] 🐞 Bug fix (Non-breaking change which fixes an issue)
- [x] ✨ Feature (Non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🛠️ Code refactoring (No code changes, no API changes)
- [ ] 🏗️ Build configuration change
- [ ] 📚 Documentation
- [ ] 🧹 Chore
- [ ] 💡 Other... Please describe

## Pull Request Checklist

- [x] 🚀 I have reviewed my own code and ensured it follows the project's coding standards.
- [x] 🧪 I have added unit tests and widget tests (if necessary) and they pass.
- [x] 📚 I have updated documentation (if necessary).
- [x] 🤖 I have provided clear and informative commit messages.