### PR TITLE
chore: update all links to point to `thisissandipp`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -3,7 +3,7 @@ description: Create a report to help us improve
 title: "fix: "
 labels: [bug]
 assignees:
-  - thecodexhub
+  - thisissandipp
 body:
   - type: markdown
     attributes:
@@ -40,7 +40,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/thecodexhub/typethis/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/thisissandipp/typethis/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,7 +3,7 @@ description: A new feature to be added to the project
 title: "feat: "
 labels: [feature]
 assignees:
-  - thecodexhub
+  - thisissandipp
 body:
   - type: markdown
     attributes:
@@ -37,7 +37,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/thecodexhub/typethis/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/thisissandipp/typethis/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -18,5 +18,8 @@
   "words": [
     "typethis",
     "thecodexhub",
+    "Sandip",
+    "Pramanik",
+    "thisissandipp"
   ]
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-thecodexhubofficial@gmail.com.
+thisissandipp@gmail.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeThis
 
-[![build](https://github.com/thecodexhub/typethis/actions/workflows/main.yml/badge.svg)](https://github.com/thecodexhub/typethis/actions)
+[![build](https://github.com/thisissandipp/typethis/actions/workflows/main.yml/badge.svg)](https://github.com/thisissandipp/typethis/actions)
 [![codecov](https://codecov.io/gh/thecodexhub/typethis/graph/badge.svg?token=7FY2DF2DS1)](https://codecov.io/gh/thecodexhub/typethis)
 [![License: MIT](https://img.shields.io/badge/License-MIT-purple.svg)](https://opensource.org/licenses/MIT)
 [![Package Version](https://img.shields.io/pub/v/typethis.svg)](https://pub.dev/packages/typethis)
@@ -111,7 +111,7 @@ Use the TypeThisController to manage and control the animations as well. [Read h
 
 ## Demo
 
-[![Demo](demo/typethis.gif)](https://github.com/thecodexhub/typethis)
+[![Demo](demo/typethis.gif)](https://github.com/thisissandipp/typethis)
 
 ## License
 
@@ -121,11 +121,11 @@ The project is released under the [MIT License](LICENSE). Learn more about it, [
 
 <p align="center">
   <p align="center">
-    Developed and Maintained with 💜 by <a href="https://github.com/thecodexhub">thecodexhub</a>
+    Developed and Maintained with 💜 by <a href="https://github.com/thisissandipp">Sandip Pramanik</a>
   </p>
   <p align="center">
-    <a href="https://github.com/thecodexhub/typethis">
-      <img src="https://img.shields.io/github/stars/thecodexhub/typethis?label=%E2%AD%90%20Star%20this%20repository&color=%23FFBF00" alt="Star this repository">
+    <a href="https://github.com/thisissandipp/typethis">
+      <img src="https://img.shields.io/github/stars/thisissandipp/typethis?label=%E2%AD%90%20Star%20this%20repository&color=%23FFBF00" alt="Star this repository">
     </a>
   </p>
 </p>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: typethis
 description: A flutter package that aims to simplify versatile typing animation with rich text effects and other operations (reset, freeze, unfreeze).
-repository: https://github.com/thecodexhub/typethis
-issue_tracker: https://github.com/thecodexhub/typethis/issues
-homepage: https://github.com/thecodexhub/typethis
-documentation: https://github.com/thecodexhub/typethis
+repository: https://github.com/thisissandipp/typethis
+issue_tracker: https://github.com/thisissandipp/typethis/issues
+homepage: https://github.com/thisissandipp/typethis
+documentation: https://github.com/thisissandipp/typethis
 
 version: 1.0.2
 


### PR DESCRIPTION
## Description

- fix: update all the links to point to the correct profile (`thisissandipp`, instead of `thecodexhub`).

## Type of Pull Request

- [ ] 🐞 Bug fix (Non-breaking change which fixes issue)
- [ ] ✨ Feature (Non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🛠️ Code refactoring (No code changes, no API changes)
- [ ] 🏗️ Build configuration change
- [ ] 📚 Documentation
- [x] 🧹 Chore
- [ ] 💡 Other... Please describe

## Pull Request Checklist

- [x] 🚀 I have reviewed my own code and ensured it follows the project's coding standards.
- [x] 🧪 I have added unit tests (if necessary) and they pass.
- [x] 📚 I have updated documentation (if necessary).
- [x] 🤖 I have provided clear and informative commit messages.
